### PR TITLE
The individual outcomes are now in their own polymer component

### DIFF
--- a/d2l-outcome-level-of-achievement.html
+++ b/d2l-outcome-level-of-achievement.html
@@ -11,7 +11,7 @@ Polymer Web-Component to display levels of achievements
 		<style>
 			:host {
 				display: inline-block;
-				margin: 0 0 30px 0;
+				margin: 0 0 1.5rem 0;
 			}
 
 			d2l-squishy-button-selector {
@@ -24,7 +24,7 @@ Polymer Web-Component to display levels of achievements
 				margin-right: 0;
 				padding-left: 0;
 				padding-right: 0;
-				margin-bottom: 12px;
+				margin-bottom: 0.6rem;
 			}
 
 			d2l-squishy-button > div {

--- a/d2l-outcome-level-of-achievement.html
+++ b/d2l-outcome-level-of-achievement.html
@@ -1,0 +1,54 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="squishy-button-selector/d2l-squishy-button-selector.html">
+<link rel="import" href="squishy-button-selector/d2l-squishy-button.html">
+
+<!--
+`d2l-outcome-level-of-achievement`
+Polymer Web-Component to display levels of achievements
+-->
+<dom-module id="d2l-outcome-level-of-achievement">
+	<template strip-whitespace>
+		<style>
+			:host {
+				display: inline-block;
+				margin: 0 0 30px 0;
+			}
+
+			d2l-squishy-button-selector {
+				width: 100%;
+			}
+
+			p {
+				@apply --d2l-body-small-text;
+				margin-left: 0;
+				margin-right: 0;
+				padding-left: 0;
+				padding-right: 0;
+				margin-bottom: 12px;
+			}
+
+			d2l-squishy-button > div {
+				font-weight: bold;
+			}
+		</style>
+
+		<p>[[text]]</p>
+		<d2l-squishy-button-selector>
+			<template is="dom-repeat" items=[[levels]]>
+				<d2l-squishy-button style$="--d2l-squishy-button-selected-color: [[item.color]]">
+					<div> [[item.content]] </div>
+				</d2l-squishy-button>
+			</template>
+		</d2l-squishy-button-selector>
+
+	</template>
+	<script>
+		Polymer({
+			is: 'd2l-outcome-level-of-achievement',
+			properties: {
+				text: String,
+				levels: Array
+			}
+		});
+	</script>
+</dom-module>

--- a/d2l-outcomes-level-of-achievements.html
+++ b/d2l-outcomes-level-of-achievements.html
@@ -65,7 +65,7 @@ Polymer Web-Component to display levels of achievements
 									{ content: 'MIGHTY SWELL', color: 'yellow' }
 								]
 							}
-						]
+						];
 					}
 				}
 			}

--- a/d2l-outcomes-level-of-achievements.html
+++ b/d2l-outcomes-level-of-achievements.html
@@ -11,7 +11,7 @@ Polymer Web-Component to display levels of achievements
 	<template strip-whitespace>
 		<style>
 			:host {
-				margin: 24px 10px 30px 10px;
+				margin: 1.2rem 0.5rem 1.5rem 0.5rem;
 				display: inline-block;
 			}
 

--- a/d2l-outcomes-level-of-achievements.html
+++ b/d2l-outcomes-level-of-achievements.html
@@ -1,6 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="squishy-button-selector/d2l-squishy-button-selector.html">
-<link rel="import" href="squishy-button-selector/d2l-squishy-button.html">
+<link rel="import" href="d2l-outcome-level-of-achievement.html">
 
 <!--
 `d2l-outcomes-level-of-achievements`
@@ -11,18 +10,23 @@ Polymer Web-Component to display levels of achievements
 <dom-module id="d2l-outcomes-level-of-achievements">
 	<template strip-whitespace>
 		<style>
-			d2l-squishy-button-selector {
-				width: 100%;
+			:host {
+				margin: 24px 10px 30px 10px;
+				display: inline-block;
+			}
+
+			d2l-outcome-level-of-achievement:last-of-type {
+				margin-bottom: 0;
 			}
 		</style>
 
-		<d2l-squishy-button-selector>
-			<template is="dom-repeat" items=[[_buttons]]>
-				<d2l-squishy-button style$="--d2l-squishy-button-selected-color: [[item.color]]">
-					<div> [[item.content]] </div>
-				</d2l-squishy-button>
-			</template>
-		</d2l-squishy-button-selector>
+		<template is="dom-repeat" items=[[_outcomeData]]>
+			<d2l-outcome-level-of-achievement
+				text="[[item.text]]"
+				levels="[[item.levels]]"
+			>
+			</d2l-outcome-level-of-achievement>
+		</template>
 
 	</template>
 	<script>
@@ -41,17 +45,30 @@ Polymer Web-Component to display levels of achievements
 					type: String,
 					value: null
 				},
-				_buttons: {
+				_outcomeData: {
 					type: Array,
 					value: function() {
 						return [
-							{ content: 'level 1', color: 'red' },
-							{ content: 'level 2', color: 'blue' },
-							{ content: 'level 3', color: 'green' }
-						];
+							{
+								text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+								levels: [
+									{ content: 'level 1', color: 'red' },
+									{ content: 'level 2', color: 'blue' },
+									{ content: 'level 3', color: 'green' }
+								]
+							},
+							{
+								text: 'Bacon ipsum dolor amet shoulder t-bone chicken pancetta beef ribs, corned beef salami rump pork belly pastrami ground round sirloin sausage beef. Short loin prosciutto strip steak, ground round bacon pork belly frankfurter pancetta cow chicken porchetta andouille burgdoggen filet mignon short ribs. Cupim corned beef meatball filet mignon, pork ham ribeye fatback bresaola ball tip flank sausage.',
+								levels: [
+									{ content: 'BAD', color: 'red' },
+									{ content: 'NOT BAD', color: 'orange' },
+									{ content: 'MIGHTY SWELL', color: 'yellow' }
+								]
+							}
+						]
 					}
 				}
-			},
-			behaviors: []
+			}
 		});
 	</script>
+</dom-module>

--- a/squishy-button-selector/d2l-squishy-button-selector.html
+++ b/squishy-button-selector/d2l-squishy-button-selector.html
@@ -66,10 +66,6 @@ Polymer Web-Component for a responsive list of selectable buttons
 					value: false,
 					reflectToAttribute: true,
 					observer: '_readOnlyChanged'
-				},
-				ariaLabel: {
-					type: String,
-					reflectToAttribute: true
 				}
 			},
 


### PR DESCRIPTION
This is just a quick PR to break the individual outcomes out of their parent component and make it look like the design (I'm not getting the actual data yet so test data is used at the moment)

Requires: https://github.com/Brightspace/outcomes-level-of-achievement-ui/pull/2