### PR TITLE
remove a bit of the jank

### DIFF
--- a/d2l-outcomes-level-of-achievements.html
+++ b/d2l-outcomes-level-of-achievements.html
@@ -94,7 +94,7 @@ Polymer Web-Component to display levels of achievements
 				}
 
 				this.performSirenAction(action)
-					.catch(function() {})
+					.catch(function() {});
 			}
 		});
 	</script>

--- a/d2l-outcomes-level-of-achievements.html
+++ b/d2l-outcomes-level-of-achievements.html
@@ -41,6 +41,7 @@ Polymer Web-Component to display levels of achievements
 	<script>
 		Polymer({
 			is: 'd2l-outcomes-level-of-achievements',
+
 			properties: {
 				_hasAction: Boolean
 			},
@@ -94,9 +95,6 @@ Polymer Web-Component to display levels of achievements
 
 				this.performSirenAction(action)
 					.catch(function() {})
-					.then(function() {
-						window.D2L.Siren.EntityStore.fetch(this.href, this.token, true);
-					}.bind(this));
 			}
 		});
 	</script>


### PR DESCRIPTION
Calling the action already refreshes the entity in the store, refetching it was just compounding the jank when the user wants to click things super fast

With this fix in there's still a bit of jankieness, but I don't think it's a big problem any more (we'll see when deselecting is a thing, though)