### PR TITLE
DE31982 -- Fix disabled buttons being selectable when using NVDA

### DIFF
--- a/d2l-outcomes-level-of-achievements.html
+++ b/d2l-outcomes-level-of-achievements.html
@@ -38,7 +38,6 @@ Polymer Web-Component to display levels of achievements
 					selected="[[item.selected]]"
 					button-data="[[_getButtonData(item)]]"
 					id="item-[[index]]"
-					disabled="[[_getIsDisabled(readOnly,_hasAction)]]"
 				>
 					[[item.text]]
 				</d2l-squishy-button>

--- a/d2l-outcomes-level-of-achievements.html
+++ b/d2l-outcomes-level-of-achievements.html
@@ -30,6 +30,7 @@ Polymer Web-Component to display levels of achievements
 
 		<d2l-squishy-button-selector
 			tooltip-position="top"
+			disabled="[[_getIsDisabled(readOnly,_hasAction)]]"
 		>
 			<template is="dom-repeat" items="[[_demonstrationLevels]]">
 				<d2l-squishy-button
@@ -37,6 +38,7 @@ Polymer Web-Component to display levels of achievements
 					selected="[[item.selected]]"
 					button-data="[[_getButtonData(item)]]"
 					id="item-[[index]]"
+					disabled="[[_getIsDisabled(readOnly,_hasAction)]]"
 				>
 					[[item.text]]
 				</d2l-squishy-button>
@@ -51,18 +53,10 @@ Polymer Web-Component to display levels of achievements
 			properties: {
 				readOnly: {
 					type: Boolean,
-					value: false,
-					observer: '_readOnlyChanged'
+					value: false
 				},
-
-				_hasAction: {
-					type: Boolean,
-					observer: '_hasActionChanged'
-				},
-
-				_demonstrationLevels: {
-					type: Array
-				}
+				_hasAction: Boolean,
+				_demonstrationLevels: Array
 			},
 
 			observers: [
@@ -123,20 +117,8 @@ Polymer Web-Component to display levels of achievements
 				this.performSirenAction(action)
 					.catch(function() {});
 			},
-			_readOnlyChanged: function(readOnly) {
-				this._maybeDisable(readOnly, this._hasAction);
-			},
-			_hasActionChanged: function(hasAction) {
-				this._maybeDisable(this.readOnly, hasAction);
-			},
-			_maybeDisable: function(readOnly, hasAction) {
-				var selector = this.$$('d2l-squishy-button-selector');
-				if (readOnly || hasAction === false) {
-					selector.setAttribute('disabled', '');
-					return;
-				}
-
-				selector.removeAttribute('disabled');
+			_getIsDisabled: function(readOnly, hasAction) {
+				return !!readOnly || hasAction === false;
 			}
 		});
 	</script>

--- a/squishy-button-selector/d2l-squishy-button-selector.html
+++ b/squishy-button-selector/d2l-squishy-button-selector.html
@@ -286,6 +286,7 @@ Polymer Web-Component for a responsive list of selectable buttons
 			_disabledChanged: function(disabled) {
 				var buttonList = this;
 
+				this._setButtonProperties();
 				if (disabled && buttonList.getAttribute('tabindex') === '-1'
 					|| !disabled && buttonList.getAttribute('tabindex') === '0'
 				) {

--- a/squishy-button-selector/d2l-squishy-button-selector.html
+++ b/squishy-button-selector/d2l-squishy-button-selector.html
@@ -73,6 +73,12 @@ Polymer Web-Component for a responsive list of selectable buttons
 					reflectToAttribute: true,
 					observer: '_disabledChanged'
 				},
+				ariaDisabled: {
+					type: Boolean,
+					reflectToAttribute: true,
+					readOnly: true,
+					computed: '_getDisabled(disabled)'
+				},
 				ariaLabel: {
 					type: String,
 					reflectToAttribute: true
@@ -124,6 +130,10 @@ Polymer Web-Component for a responsive list of selectable buttons
 				this.removeEventListener('focus', this._onFocus);
 				this.removeEventListener('blur', this._onBlur);
 				this.removeEventListener('mouseover', this._onHover);
+			},
+
+			_getDisabled: function(disabled) {
+				return disabled;
 			},
 
 			_handleDomChanges: function() {

--- a/squishy-button-selector/d2l-squishy-button.html
+++ b/squishy-button-selector/d2l-squishy-button.html
@@ -123,6 +123,15 @@
 					observer: '_handleSelected'
 				},
 
+				disabled: Boolean,
+
+				ariaDisabled: {
+					type: Boolean,
+					reflectToAttribute: true,
+					readOnly: true,
+					computed: '_getDisabled(disabled)'
+				},
+
 				index: {
 					type: Number,
 					reflectToAttribute: true
@@ -190,6 +199,10 @@
 					this._measureSize();
 					this._updateColor(this.color);
 				});
+			},
+
+			_getDisabled: function(disabled) {
+				return disabled;
 			},
 
 			detached: function() {


### PR DESCRIPTION
* Fixed a bug where you could select buttons that are supposed to be disabled by using the NVDA screenreader to focus the button
* Simplified logic for setting `disabled` attribute by replacing observers and setters with a computed value