### PR TITLE
Update Tooltip Right Boundary

### DIFF
--- a/demo/d2l-squishy-button-selector.html
+++ b/demo/d2l-squishy-button-selector.html
@@ -23,7 +23,6 @@ window.d2lfetch = {
 	<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
 	<script type="module" src="../squishy-button-selector/d2l-squishy-button-selector.js"></script>
 	<script type="module" src="../squishy-button-selector/d2l-squishy-button.js"></script>
-	<script type="module" src="../../d2l-tooltip/d2l-tooltip.js"></script>
 
 	<script type="module" src="../../d2l-typography/d2l-typography.js"></script>
 	<!-- FIXME(polymer-modulizer):

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-outcomes-level-of-achievements-ui",
   "name": "d2l-outcomes-level-of-achievements",
-  "version": "2.1.9",
+  "version": "2.8.12",
   "directories": {
     "test": "test"
   },
@@ -45,13 +45,13 @@
     "whatwg-fetch": "^2.0.0"
   },
   "dependencies": {
+    "@brightspace-ui/core": "^1.41.0",
     "@polymer/polymer": "^3.0.0",
     "d2l-colors": "BrightspaceUI/colors#semver:^4",
     "d2l-hypermedia-constants": "^6",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
     "d2l-polymer-siren-behaviors": "Brightspace/polymer-siren-behaviors#semver:^1",
-    "d2l-tooltip": "BrightspaceUI/tooltip#semver:^3",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "fastdom": "^1.0.8"
   },

--- a/squishy-button-selector/d2l-squishy-button.js
+++ b/squishy-button-selector/d2l-squishy-button.js
@@ -1,7 +1,7 @@
 import '@polymer/polymer/polymer-legacy.js';
+import '@brightspace-ui/core/components/tooltip/tooltip.js';
 import 'd2l-colors/d2l-colors.js';
 import 'd2l-polymer-behaviors/d2l-dom.js';
-import 'd2l-tooltip/d2l-tooltip.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
@@ -99,7 +99,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-squishy-button">
 			}
 		</style>
 
-		<d2l-tooltip id="tooltip[[index]]" hidden$="[[!_textOverflowing]]" position$="[[tooltipPosition]]" boundary="[[_containerBoundary]]" aria-hidden="">[[text]]</d2l-tooltip>
+		<d2l-tooltip id="tooltip[[index]]" hidden$="[[!_textOverflowing]]" position$="[[tooltipPosition]]" boundary="{&quot;left&quot;: 0, &quot;right&quot;:0}" aria-hidden="">[[text]]</d2l-tooltip>
 
 		<div class="d2l-squishy-button-container">
 			<div id="textwrapper" class="d2l-squishy-button-inner">
@@ -108,7 +108,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-squishy-button">
 			</div>
 		</div>
 	</template>
-	
+
 </dom-module>`;
 
 document.head.appendChild($_documentContainer.content);
@@ -173,10 +173,6 @@ Polymer({
 			value: 'bottom',
 			reflectToAttribute: true
 		},
-
-		_containerBoundary: {
-			type: Object
-		},
 	},
 
 	listeners: {
@@ -186,14 +182,6 @@ Polymer({
 
 	ready: function() {
 		afterNextRender(this, /* @this */ function() {
-			this.__squishySelector = D2L.Dom.findComposedAncestor(this, function(node) {
-				if (!node || node.nodeType !== 1) {
-					return false;
-				}
-
-				return node.nodeName === 'D2L-SQUISHY-BUTTON-SELECTOR';
-			});
-
 			this._measureSize = this._measureSize.bind(this);
 			this._handleDomChanges = this._handleDomChanges.bind(this);
 
@@ -210,7 +198,6 @@ Polymer({
 	},
 
 	detached: function() {
-		this.__squishySelector = null;
 		window.removeEventListener('resize', this._measureSize);
 		if (this._slotObserver) {
 			dom(this).unobserveNodes(this._slotObserver);
@@ -236,11 +223,6 @@ Polymer({
 			var innerHeight = this.$.textarea.offsetHeight;
 			var outerHeight = this.$.textwrapper.offsetHeight;
 			this._textOverflowing = innerHeight > outerHeight;
-
-			this._containerBoundary = {
-				left: 0,
-				right: (this.__squishySelector || this).offsetWidth
-			};
 		}.bind(this));
 	},
 


### PR DESCRIPTION
# Changes
- Update the right boundary because it has been changed to be relative to the right side of its `offsetParent` rather than the left