### PR TITLE
Fix Siren Action

### DIFF
--- a/d2l-outcomes-level-of-achievements.js
+++ b/d2l-outcomes-level-of-achievements.js
@@ -60,7 +60,7 @@ export class D2lOutcomesLevelOfAchievements extends EntityMixinLit(LocalizeMixin
 
 	_renderDemonstrationLevel(item, index) {
 		return html`
-		<d2l-squishy-button color="${item.color}" ?selected="${item.selected}" button-data="${{ action: item.action }}" index="${index}" id="item-${index}">
+		<d2l-squishy-button color="${item.color}" ?selected="${item.selected}" .buttonData="${{ action: item.action }}" index="${index}" id="item-${index}">
 			${item.text}
 		</d2l-squishy-button>`;
 	}
@@ -153,10 +153,10 @@ export class D2lOutcomesLevelOfAchievements extends EntityMixinLit(LocalizeMixin
 			composed: true
 		}));
 		var action = event.detail.data.action;
-		if (!action) {
+		if (!this.token || !action) {
 			return;
 		}
-		performSirenAction(action)
+		performSirenAction(this.token, action)
 			.catch(function() { });
 	}
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-outcomes-level-of-achievements-ui",
   "name": "d2l-outcomes-level-of-achievements",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "directories": {
     "test": "test"
   },

--- a/squishy-button-selector/d2l-squishy-button.js
+++ b/squishy-button-selector/d2l-squishy-button.js
@@ -37,7 +37,7 @@ export class D2lSquishyButton extends LitElement {
 
 			buttonData: {
 				type: Object,
-				attribute: 'button-data',
+				attribute: false,
 				reflect: true
 			},
 


### PR DESCRIPTION
I've made some changes to `d2l-outcomes-level-of-achievements` to allow it to successfully perform Siren actions
* The `button-data` attribute has been changed to a `.buttonData` property. This prevents the data to be passed in as `[Object object]`.
* The `performSirenAction` function requires a token as the first parameter. Note that this is different from the behaviour in Major Version 2, which used a different library.