### PR TITLE
Make token a property in d2l-outcomes-coa-eval-override

### DIFF
--- a/d2l-outcomes-coa-eval-override.js
+++ b/d2l-outcomes-coa-eval-override.js
@@ -235,7 +235,7 @@ export class D2lOutcomesCOAEvalOverride extends EntityMixinLit(LocalizeMixin(Lit
 			tooltip-position="top"
 			?read-only="${!this._canEditLevel()}"
 			disable-suggestion=""
-			token="${this.getAttribute('token')}"
+			.token="${this.token}"
 			href="${this.getAttribute('href')}"
 			@d2l-outcomes-level-of-achievements-item-selected=${this._dispatchChangeEvent}>
 		</d2l-outcomes-level-of-achievements>`;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-outcomes-level-of-achievements-ui",
   "name": "d2l-outcomes-level-of-achievements",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
In consistent-eval, the token passed into `d2l-outcomes-coa-eval-override` and `d2l-outcomes-level-of-achievements` is a function. However, it is being parsed as a string, leading to token parsing errors when doing Siren requests. Making token a property fixes this issue.