### PR TITLE
Don't specify more than a major version for core

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "whatwg-fetch": "^2.0.0"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^1.86.0",
+    "@brightspace-ui/core": "^1",
     "@polymer/polymer": "^3.0.0",
     "d2l-hypermedia-constants": "^6",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",


### PR DESCRIPTION
After a change yesterday on this repo, I can no longer build consistent-evaluation. It fails with the error:
```
Error: Failed to execute 'define' on 'CustomElementRegistry': the name "d2l-tooltip" has already been used with this registry
      at node_modules/d2l-outcomes-level-of-achievements/node_modules/@brightspace-ui/core/components/tooltip/tooltip.js:833:16
```

Upon inspection, it seems to be because d2l-outcomes-level-of-achievements is including it's own version of core. Once I delete that version manually, the error goes away. I think it's because we're specifying a specific version of core here.