### PR TITLE
Use select-deferred event instead of using an event in coa-eval-override

### DIFF
--- a/d2l-outcomes-coa-eval-override.js
+++ b/d2l-outcomes-coa-eval-override.js
@@ -238,7 +238,6 @@ export class D2lOutcomesCOAEvalOverride extends EntityMixinLit(LocalizeMixin(Lit
 			disable-auto-save=""
 			.token="${this.token}"
 			href="${this.getAttribute('href')}"
-			@d2l-outcomes-level-of-achievements-item-selected=${this._onItemSelected}>
 		</d2l-outcomes-level-of-achievements>`;
 	}
 
@@ -361,17 +360,6 @@ export class D2lOutcomesCOAEvalOverride extends EntityMixinLit(LocalizeMixin(Lit
 			this.shadowRoot.activeElement.click();
 			event.preventDefault();
 		}
-	}
-
-	_onItemSelected(event) {
-		this._dispatchChangeEvent();
-		this.dispatchEvent(new CustomEvent('d2l-outcomes-coa-eval-override-item-selected', {
-			bubbles: true,
-			composed: true,
-			detail: {
-				action: event.detail.action
-			}
-		}));
 	}
 
 	_onOverrideButtonClicked() {

--- a/d2l-outcomes-coa-eval-override.js
+++ b/d2l-outcomes-coa-eval-override.js
@@ -238,6 +238,7 @@ export class D2lOutcomesCOAEvalOverride extends EntityMixinLit(LocalizeMixin(Lit
 			disable-auto-save=""
 			.token="${this.token}"
 			href="${this.getAttribute('href')}"
+			@d2l-outcomes-level-of-achievements-item-selected=${this._onItemSelected}>
 		</d2l-outcomes-level-of-achievements>`;
 	}
 
@@ -360,6 +361,10 @@ export class D2lOutcomesCOAEvalOverride extends EntityMixinLit(LocalizeMixin(Lit
 			this.shadowRoot.activeElement.click();
 			event.preventDefault();
 		}
+	}
+
+	_onItemSelected() {
+		this._dispatchChangeEvent();
 	}
 
 	_onOverrideButtonClicked() {

--- a/d2l-outcomes-level-of-achievements.js
+++ b/d2l-outcomes-level-of-achievements.js
@@ -164,6 +164,10 @@ export class D2lOutcomesLevelOfAchievements extends EntityMixinLit(LocalizeMixin
 	}
 
 	_onItemSelected(event) {
+		this.dispatchEvent(new CustomEvent('d2l-outcomes-level-of-achievements-item-selected', {
+			bubbles: true,
+			composed: true
+		}));
 		var action = event.detail.data.action;
 		if (!this.token || !action) {
 			return;

--- a/d2l-outcomes-level-of-achievements.js
+++ b/d2l-outcomes-level-of-achievements.js
@@ -122,7 +122,7 @@ export class D2lOutcomesLevelOfAchievements extends EntityMixinLit(LocalizeMixin
 			const level = demonstratableLevelEntities[i];
 			level.onLevelChanged(achievementLevel => {
 				var levelObj = {
-					action: level.getAction(),
+					action: level.getAction(this.disableAutoSave),
 					selected: level.isSelected(),
 					color: achievementLevel.getColor(),
 					text: achievementLevel.getName(),
@@ -164,21 +164,12 @@ export class D2lOutcomesLevelOfAchievements extends EntityMixinLit(LocalizeMixin
 	}
 
 	_onItemSelected(event) {
-		this.dispatchEvent(new CustomEvent('d2l-outcomes-level-of-achievements-item-selected', {
-			bubbles: true,
-			composed: true,
-			detail: {
-				action: event.detail.data.action
-			}
-		}));
-		if (!this.disableAutoSave) {
-			var action = event.detail.data.action;
-			if (!this.token || !action) {
-				return;
-			}
-			performSirenAction(this.token, action)
-				.catch(function() { });
+		var action = event.detail.data.action;
+		if (!this.token || !action) {
+			return;
 		}
+		performSirenAction(this.token, action)
+			.catch(function() { });
 	}
 
 	_getSuggestedLevelText(level) {

--- a/entities/DemonstratableLevelEntity.js
+++ b/entities/DemonstratableLevelEntity.js
@@ -25,7 +25,10 @@ export class DemonstratableLevelEntity extends SelflessEntity {
 		return this._entity.hasClass(DemonstratableLevelEntity.classes.suggested);
 	}
 
-	getAction() {
+	getAction(deferred = false) {
+		if (deferred) {
+			return this._entity && (this._entity.getAction('select-deferred') || this._entity.getActionByName('deselect-deferred'));
+		}
 		return this._entity && (this._entity.getActionByName('select') || this._entity.getActionByName('deselect'));
 	}
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-outcomes-level-of-achievements-ui",
   "name": "d2l-outcomes-level-of-achievements",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Instead of throwing an event, we can use the `select-deferred` action to defer the save action to consistent-eval. This removes the need to store the `select` action in consistent-eval.

(Thanks Gabe for the tip)