### PR TITLE
COA eval override fixes

### DIFF
--- a/d2l-outcomes-level-of-achievements.js
+++ b/d2l-outcomes-level-of-achievements.js
@@ -117,10 +117,11 @@ export class D2lOutcomesLevelOfAchievements extends EntityMixinLit(LocalizeMixin
 			return;
 		}
 		const demonstratableLevelEntities = entity.getAllDemonstratableLevels();
-		const demonstratableLevels = [];
+		const demonstratableLevelsDict = {};
 		for (var i = 0; i < demonstratableLevelEntities.length; i++) {
 			const level = demonstratableLevelEntities[i];
 			level.onLevelChanged(achievementLevel => {
+				const levelId = level.getLevelId();
 				var levelObj = {
 					action: level.getAction(this.disableAutoSave),
 					selected: level.isSelected(),
@@ -129,14 +130,13 @@ export class D2lOutcomesLevelOfAchievements extends EntityMixinLit(LocalizeMixin
 					isSuggested: level.isSuggested(),
 					sortOrder: achievementLevel.getSortOrder()
 				};
-				demonstratableLevels.push(levelObj);
+				demonstratableLevelsDict[levelId] = levelObj;
 			});
 		}
 		entity.subEntitiesLoaded().then(() => {
-			demonstratableLevels.sort((left, right) => {
+			this._demonstrationLevels = Object.values(demonstratableLevelsDict).sort((left, right) => {
 				return left.sortOrder - right.sortOrder;
 			});
-			this._demonstrationLevels = demonstratableLevels;
 			var firstSuggested = undefined;
 			var firstSuggestedIndex = null;
 			for (var i = 0; i < this._demonstrationLevels.length; i++) {
@@ -188,8 +188,19 @@ export class D2lOutcomesLevelOfAchievements extends EntityMixinLit(LocalizeMixin
 	}
 
 	resetToSuggested() {
-		var suggestedLevelElement = this.shadowRoot.getElementById('item-' + this._suggestedLevel.index.toString());
-		suggestedLevelElement.click();
+		this._demonstrationLevels.map((level, i) => {
+			const currentElement = this.shadowRoot.getElementById('item-' + i.toString());
+			if (!currentElement) {
+				return;
+			}
+
+			if (this._suggestedLevel && i === this._suggestedLevel.index) {
+				currentElement.select();
+			}
+			else {
+				currentElement.removeAttribute('selected');
+			}
+		});
 	}
 
 	_refresh() {

--- a/demo/data/demonstrations/3-levels.json
+++ b/demo/data/demonstrations/3-levels.json
@@ -10,6 +10,9 @@
             "rel": [
                 "item"
             ],
+            "properties": {
+                "levelId": "levelone"
+            },
             "actions": [
                 {
                     "type": "application/json",
@@ -46,6 +49,9 @@
             "rel": [
                 "item"
             ],
+            "properties": {
+                "levelId": "leveltwo"
+            },
             "actions": [
                 {
                     "type": "application/json",
@@ -82,6 +88,9 @@
             "rel": [
                 "item"
             ],
+            "properties": {
+                "levelId": "levelthree"
+            },
             "actions": [
                 {
                     "type": "application/json",

--- a/demo/data/demonstrations/4-levels-none-selected.json
+++ b/demo/data/demonstrations/4-levels-none-selected.json
@@ -10,6 +10,9 @@
             "rel": [
                 "item"
             ],
+            "properties": {
+                "levelId": "levelone"
+            },
             "actions": [
                 {
                     "type": "application/json",
@@ -46,6 +49,9 @@
             "rel": [
                 "item"
             ],
+            "properties": {
+                "levelId": "leveltwo"
+            },
             "actions": [
                 {
                     "type": "application/json",
@@ -82,6 +88,9 @@
             "rel": [
                 "item"
             ],
+            "properties": {
+                "levelId": "levelthree"
+            },
             "actions": [
                 {
                     "type": "application/json",
@@ -118,6 +127,9 @@
             "rel": [
                 "item"
             ],
+            "properties": {
+                "levelId": "levelfour"
+            },
             "actions": [
                 {
                     "type": "application/json",

--- a/demo/data/demonstrations/4-levels-selected.json
+++ b/demo/data/demonstrations/4-levels-selected.json
@@ -7,6 +7,9 @@
             "class": [
                 "demonstratable-level"
             ],
+            "properties": {
+                "levelId": "levelone"
+            },
             "rel": [
                 "item"
             ],
@@ -46,6 +49,9 @@
             "rel": [
                 "item"
             ],
+            "properties": {
+                "levelId": "leveltwo"
+            },
             "actions": [
                 {
                     "type": "application/json",
@@ -83,6 +89,9 @@
             "rel": [
                 "item"
             ],
+            "properties": {
+                "levelId": "levelthree"
+            },
             "actions": [
                 {
                     "type": "application/json",
@@ -119,6 +128,9 @@
             "rel": [
                 "item"
             ],
+            "properties": {
+                "levelId": "levelfour"
+            },
             "actions": [
                 {
                     "type": "application/json",

--- a/demo/data/demonstrations/calculated/decaying-average-new-assessments.json
+++ b/demo/data/demonstrations/calculated/decaying-average-new-assessments.json
@@ -14,6 +14,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelone"
+      },
       "actions": [
         {
           "type": "application/json",
@@ -51,6 +54,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "leveltwo"
+      },
       "actions": [
         {
           "type": "application/json",
@@ -88,6 +94,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelthree"
+      },
       "actions": [
         {
           "type": "application/json",
@@ -124,6 +133,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelfour"
+      },
       "actions": [
         {
           "type": "application/json",

--- a/demo/data/demonstrations/calculated/decaying-average.json
+++ b/demo/data/demonstrations/calculated/decaying-average.json
@@ -14,6 +14,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelone"
+      },
       "actions": [
         {
           "type": "application/json",
@@ -50,6 +53,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "leveltwo"
+      },
       "actions": [
         {
           "type": "application/json",
@@ -88,6 +94,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelthree"
+      },
       "actions": [
         {
           "type": "application/json",
@@ -124,6 +133,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelfour"
+      },
       "actions": [
         {
           "type": "application/json",

--- a/demo/data/demonstrations/calculated/highest.json
+++ b/demo/data/demonstrations/calculated/highest.json
@@ -13,6 +13,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelone"
+      },
       "actions": [
         {
           "type": "application/json",
@@ -49,6 +52,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "leveltwo"
+      },
       "actions": [
         {
           "type": "application/json",
@@ -85,6 +91,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelthree"
+      },
       "actions": [
         {
           "type": "application/json",
@@ -123,6 +132,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelfour"
+      },
       "actions": [
         {
           "type": "application/json",

--- a/demo/data/demonstrations/calculated/most-common-no-actions.json
+++ b/demo/data/demonstrations/calculated/most-common-no-actions.json
@@ -13,6 +13,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelone"
+      },
       "links": [
         {
           "rel": [
@@ -29,6 +32,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "leveltwo"
+      },
       "links": [
         {
           "rel": [
@@ -47,6 +53,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelthree"
+      },
       "links": [
         {
           "rel": [
@@ -63,6 +72,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelfour"
+      },
       "links": [
         {
           "rel": [

--- a/demo/data/demonstrations/calculated/most-common.json
+++ b/demo/data/demonstrations/calculated/most-common.json
@@ -13,6 +13,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelone"
+      },
       "actions": [
         {
           "type": "application/json",
@@ -49,6 +52,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "leveltwo"
+      },
       "actions": [
         {
           "type": "application/json",
@@ -87,6 +93,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelthree"
+      },
       "actions": [
         {
           "type": "application/json",
@@ -123,6 +132,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelfour"
+      },
       "actions": [
         {
           "type": "application/json",

--- a/demo/data/demonstrations/calculated/most-recent.json
+++ b/demo/data/demonstrations/calculated/most-recent.json
@@ -13,6 +13,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelone"
+      },
       "actions": [
         {
           "type": "application/json",
@@ -49,6 +52,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "leveltwo"
+      },
       "actions": [
         {
           "type": "application/json",
@@ -87,6 +93,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelthree"
+      },
       "actions": [
         {
           "type": "application/json",
@@ -123,6 +132,9 @@
       "rel": [
         "item"
       ],
+      "properties": {
+        "levelId": "levelfour"
+      },
       "actions": [
         {
           "type": "application/json",

--- a/demo/data/demonstrations/suggested-level.json
+++ b/demo/data/demonstrations/suggested-level.json
@@ -10,6 +10,9 @@
             "rel": [
                 "item"
             ],
+            "properties": {
+                "levelId": "levelone"
+            },
             "actions": [
                 {
                     "type": "application/json",
@@ -48,6 +51,9 @@
             "rel": [
                 "item"
             ],
+            "properties": {
+                "levelId": "leveltwo"
+            },
             "actions": [
                 {
                     "type": "application/json",
@@ -84,6 +90,9 @@
             "rel": [
                 "item"
             ],
+            "properties": {
+                "levelId": "levelthree"
+            },
             "actions": [
                 {
                     "type": "application/json",

--- a/entities/DemonstratableLevelEntity.js
+++ b/entities/DemonstratableLevelEntity.js
@@ -32,6 +32,10 @@ export class DemonstratableLevelEntity extends SelflessEntity {
 		return this._entity && (this._entity.getActionByName('select') || this._entity.getActionByName('deselect'));
 	}
 
+	getLevelId() {
+		return this._entity && this._entity.properties && this._entity.properties.levelId;
+	}
+
 	getSelectAction() {
 		return this._entity && this._entity.getActionByName('select');
 	}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-outcomes-level-of-achievements-ui",
   "name": "d2l-outcomes-level-of-achievements",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "directories": {
     "test": "test"
   },

--- a/squishy-button-selector/d2l-squishy-button.js
+++ b/squishy-button-selector/d2l-squishy-button.js
@@ -217,6 +217,12 @@ export class D2lSquishyButton extends LitElement {
 		return disabled;
 	}
 
+	select() {
+		if (!this.hasAttribute('selected')) {
+			this.click();
+		}
+	}
+
 	detached() {
 		window.removeEventListener('resize', this._measureSize);
 		this.shadowRoot.removeEventListener('slotchange', this._handleDomChanges);


### PR DESCRIPTION
FIxes various behavior issues with the COA override component including:

- achievement level buttons doubling after toggling manual override
- issues with manual override behavior when no auto-calculated value is present
- clicking "clear manual override" deselecting the suggested level if it was already selected