### PR TITLE
Fix tooltip and screen reader issues

### DIFF
--- a/d2l-outcomes-level-of-achievements.js
+++ b/d2l-outcomes-level-of-achievements.js
@@ -74,7 +74,7 @@ export class D2lOutcomesLevelOfAchievements extends EntityMixinLit(LocalizeMixin
 
 	_renderDemonstrationLevel(item, index) {
 		return html`
-		<d2l-squishy-button color="${item.color}" ?selected="${item.selected}" .buttonData="${{ action: item.action }}" index="${index}" id="item-${index}">
+		<d2l-squishy-button role="radio" color="${item.color}" ?selected="${item.selected}" .buttonData="${{ action: item.action }}" index="${index}" id="item-${index}">
 			${item.text}
 		</d2l-squishy-button>`;
 	}
@@ -82,7 +82,7 @@ export class D2lOutcomesLevelOfAchievements extends EntityMixinLit(LocalizeMixin
 	render() {
 		return html`
 			${this._renderSuggestedLevel()}
-			<d2l-squishy-button-selector tooltip-position="top" ?disabled=${this.readOnly || !this._hasAction}>
+			<d2l-squishy-button-selector role="radiogroup" tooltip-position="top" ?disabled=${this.readOnly || !this._hasAction}>
 				${this._demonstrationLevels.map((item, i) => this._renderDemonstrationLevel(item, i))}
 			</d2l-squishy-button-selector>`;
 	}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-outcomes-level-of-achievements-ui",
   "name": "d2l-outcomes-level-of-achievements",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "directories": {
     "test": "test"
   },

--- a/squishy-button-selector/d2l-squishy-button.js
+++ b/squishy-button-selector/d2l-squishy-button.js
@@ -65,7 +65,8 @@ export class D2lSquishyButton extends LitElement {
 			tooltipPosition: {
 				type: String,
 				value: 'bottom',
-				reflect: true
+				reflect: true,
+				attribute: 'tooltip-position'
 			},
 		};
 	}
@@ -189,11 +190,11 @@ export class D2lSquishyButton extends LitElement {
 		return html`
 			<d2l-tooltip 
 				id="tooltip${this.index}"
-				hidden="${!this._textOverflowing}"
+				?hidden=${!this._textOverflowing}
 				position="${this.tooltipPosition}"
 				boundary="{&quot;left&quot;: 0, &quot;right&quot;:0}"
 				aria-hidden="">
-				${this.text}
+				<span aria-hidden="true">${this.text}</span>
 			</d2l-tooltip>
 
 			<div class="d2l-squishy-button-container d2l-body-small">
@@ -238,8 +239,8 @@ export class D2lSquishyButton extends LitElement {
 	}
 
 	_measureSize() {
-		var innerHeight = this.shadowRoot.getElementById('textarea').innerHTML.offsetHeight;
-		var outerHeight = this.shadowRoot.getElementById('textwrapper').innerHTML.offsetHeight;
+		var innerHeight = this.shadowRoot.getElementById('textarea').offsetHeight;
+		var outerHeight = this.shadowRoot.getElementById('textwrapper').offsetHeight;
 		this._textOverflowing = innerHeight > outerHeight;
 	}
 


### PR DESCRIPTION
The achievements selector was not behaving as radio buttons. The tooltips would also not show up if the text was too long

Changes:
* Add `radio` and `radiogroup` roles to `squishy-button` and `squishy-button-selector` respectively
* Correctly get the heights of `textarea` and `textwrapper` to correctly get the `_textOverflowing` attribute
* Add attribute name to the `tooltipPosition` attribute in `squishy-selector`
* Make the `hidden` attribute for the tooltip a boolean attribute
* Add `aria-hidden` attribute within the tooltip so that the screenreader doesn't say the button text twice

https://rally1.rallydev.com/#/detail/defect/454039300948?fdp=true