### PR TITLE
Allow publish of save-deferred demonstration

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -15,3 +15,9 @@ export const calcMethods = {
 	mostRecent: 'MostRecent',
 	none: 'None'
 };
+
+export const evalTypes = {
+	automatic: 'automatic',	// No manual override and no feedback (unlocked)
+	snapshot: 'snapshot',	// No manual override but has feedback (locked)
+	override: 'override'	// Manual override (locked)
+}

--- a/consts.js
+++ b/consts.js
@@ -20,4 +20,4 @@ export const evalTypes = {
 	automatic: 'automatic',	// No manual override and no feedback (unlocked)
 	snapshot: 'snapshot',	// No manual override but has feedback (locked)
 	override: 'override'	// Manual override (locked)
-}
+};

--- a/d2l-outcomes-coa-eval-override.js
+++ b/d2l-outcomes-coa-eval-override.js
@@ -430,7 +430,7 @@ export class D2lOutcomesCOAEvalOverride extends EntityMixinLit(LocalizeMixin(Lit
 
 			if (this._isOverrideActive) {
 				evalTypeField.value = evalTypes.override;
-			} else if (feedbackHtml) {
+			} else if (feedbackHtml || this._isCalculationUpdateNeeded()) {
 				evalTypeField.value = evalTypes.snapshot;
 			} else {
 				evalTypeField.value = evalTypes.automatic;

--- a/d2l-outcomes-coa-eval-override.js
+++ b/d2l-outcomes-coa-eval-override.js
@@ -328,21 +328,12 @@ export class D2lOutcomesCOAEvalOverride extends EntityMixinLit(LocalizeMixin(Lit
 				helpPopupItems.push(helpItemObj);
 			});
 
-			let suggestedLevel, selectedLevel;
 			let isOverrideActive = false;
 			let isOverrideAllowed = false;
 			for (var i = 0; i < levels.length; i++) {
 				const level = levels[i];
-				const suggested = level.isSuggested();
-				const selected = level.isSelected();
 				const selectAction = level.getSelectAction();
 
-				if (selected) {
-					selectedLevel = level.getLevelId();
-				}
-				if (suggested) {
-					suggestedLevel = level.getLevelId();
-				}
 				if (selectAction) {
 					isOverrideAllowed = true;
 				}

--- a/d2l-outcomes-coa-eval-override.js
+++ b/d2l-outcomes-coa-eval-override.js
@@ -355,7 +355,7 @@ export class D2lOutcomesCOAEvalOverride extends EntityMixinLit(LocalizeMixin(Lit
 	}
 
 	_isCalculationUpdateNeeded() {
-		return !!this._calculationMethod && this._newAssessmentsAdded && this._isOverrideActive;
+		return !!this._calculationMethod && this._newAssessmentsAdded;
 	}
 
 	_canEditLevel() {

--- a/d2l-outcomes-level-of-achievements.js
+++ b/d2l-outcomes-level-of-achievements.js
@@ -188,6 +188,7 @@ export class D2lOutcomesLevelOfAchievements extends EntityMixinLit(LocalizeMixin
 	}
 
 	resetToSuggested() {
+		let suggestedElement;
 		this._demonstrationLevels.map((level, i) => {
 			const currentElement = this.shadowRoot.getElementById('item-' + i.toString());
 			if (!currentElement) {
@@ -195,12 +196,16 @@ export class D2lOutcomesLevelOfAchievements extends EntityMixinLit(LocalizeMixin
 			}
 
 			if (this._suggestedLevel && i === this._suggestedLevel.index) {
-				currentElement.select();
+				suggestedElement = currentElement;
 			}
 			else if (currentElement.hasAttribute('selected')) {
 				currentElement.click();
 			}
 		});
+
+		if (suggestedElement) {
+			suggestedElement.select();
+		}
 	}
 
 	_refresh() {

--- a/entities/DemonstrationEntity.js
+++ b/entities/DemonstrationEntity.js
@@ -9,13 +9,13 @@ export class DemonstrationEntity extends Entity {
 		return {
 			masteryOverride: 'mastery-override',
 			masterySnapshot: 'mastery-snapshot'
-		}
+		};
 	}
 
 	static get actions() {
 		return {
 			publish: 'publish'
-		}
+		};
 	}
 
 	getCalculatedValue() {

--- a/entities/DemonstrationEntity.js
+++ b/entities/DemonstrationEntity.js
@@ -5,6 +5,19 @@ import { CalculationMethodEntity } from './CalculationMethodEntity';
 export class DemonstrationEntity extends Entity {
 	static get class() { return 'demonstration'; }
 
+	static get classes() {
+		return {
+			masteryOverride: 'mastery-override',
+			masterySnapshot: 'mastery-snapshot'
+		}
+	}
+
+	static get actions() {
+		return {
+			publish: 'publish'
+		}
+	}
+
 	getCalculatedValue() {
 		return this._entity && this._entity.properties && this._entity.properties.calculatedValue;
 	}
@@ -28,6 +41,14 @@ export class DemonstrationEntity extends Entity {
 		}
 		const levels = this._entity.getSubEntitiesByClass(DemonstratableLevelEntity.class);
 		return levels.map(level => new DemonstratableLevelEntity(this, level));
+	}
+
+	getPublishAction() {
+		return this._entity.getActionByName(DemonstrationEntity.actions.publish);
+	}
+
+	isManualOverride() {
+		return this._entity.hasClass(DemonstrationEntity.classes.masteryOverride);
 	}
 
 	onCalcMethodChanged(onChange) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-outcomes-level-of-achievements-ui",
   "name": "d2l-outcomes-level-of-achievements",
-  "version": "3.0.12",
+  "version": "3.0.13",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
These 3 PRs are related to each other:
https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/pull/181
https://github.com/Brightspace/outcomes-level-of-achievement-ui/pull/64
https://github.com/Brightspace/d2l-outcomes-overall-achievement/pull/59

Recently, the COA `publish` action now has a field that requires knowledge of the state of the COA component and the feedback contents. As a result, the `publish` action is now moved to the COA component itself and is called using the `d2l-save-evaluation` event.

Changes:
* Use the `mastery-override` class to determine if a demonstration is overridden
* Use the `d2l-save-evaluation` event to publish the demonstration with the proper evalType

https://rally1.rallydev.com/#/detail/defect/455925703800?fdp=true
