### PR TITLE
DE41425 - Add Siren action promise to change event

### DIFF
--- a/d2l-outcomes-coa-eval-override.js
+++ b/d2l-outcomes-coa-eval-override.js
@@ -452,7 +452,7 @@ export class D2lOutcomesCOAEvalOverride extends EntityMixinLit(LocalizeMixin(Lit
 			bubbles: true,
 			composed: true,
 			detail: {
-				sirenActionPromise
+				sirenActionPromise: sirenActionPromise
 			}
 		}));
 	}

--- a/d2l-outcomes-coa-eval-override.js
+++ b/d2l-outcomes-coa-eval-override.js
@@ -369,8 +369,8 @@ export class D2lOutcomesCOAEvalOverride extends EntityMixinLit(LocalizeMixin(Lit
 		}
 	}
 
-	_onItemSelected() {
-		this._dispatchChangeEvent();
+	_onItemSelected(e) {
+		this._dispatchChangeEvent(e.detail && e.detail.sirenActionPromise);
 	}
 
 	_onOverrideButtonClicked() {
@@ -447,10 +447,13 @@ export class D2lOutcomesCOAEvalOverride extends EntityMixinLit(LocalizeMixin(Lit
 		}));
 	}
 
-	_dispatchChangeEvent() {
+	_dispatchChangeEvent(sirenActionPromise = undefined) {
 		this.dispatchEvent(new CustomEvent('d2l-outcomes-coa-eval-override-change', {
 			bubbles: true,
-			composed: true
+			composed: true,
+			detail: {
+				sirenActionPromise
+			}
 		}));
 	}
 }

--- a/d2l-outcomes-level-of-achievements.js
+++ b/d2l-outcomes-level-of-achievements.js
@@ -164,16 +164,20 @@ export class D2lOutcomesLevelOfAchievements extends EntityMixinLit(LocalizeMixin
 	}
 
 	_onItemSelected(event) {
-		this.dispatchEvent(new CustomEvent('d2l-outcomes-level-of-achievements-item-selected', {
-			bubbles: true,
-			composed: true
-		}));
 		var action = event.detail.data.action;
 		if (!this.token || !action) {
 			return;
 		}
-		performSirenAction(this.token, action)
-			.catch(function() { });
+
+		const sirenActionPromise = performSirenAction(this.token, action)
+									.catch(function() { });
+		this.dispatchEvent(new CustomEvent('d2l-outcomes-level-of-achievements-item-selected', {
+			bubbles: true,
+			composed: true,
+			detail: {
+				sirenActionPromise
+			}
+		}));
 	}
 
 	_getSuggestedLevelText(level) {

--- a/d2l-outcomes-level-of-achievements.js
+++ b/d2l-outcomes-level-of-achievements.js
@@ -170,12 +170,12 @@ export class D2lOutcomesLevelOfAchievements extends EntityMixinLit(LocalizeMixin
 		}
 
 		const sirenActionPromise = performSirenAction(this.token, action)
-									.catch(function() { });
+			.catch(function() { });
 		this.dispatchEvent(new CustomEvent('d2l-outcomes-level-of-achievements-item-selected', {
 			bubbles: true,
 			composed: true,
 			detail: {
-				sirenActionPromise
+				sirenActionPromise: sirenActionPromise
 			}
 		}));
 	}


### PR DESCRIPTION
Related: https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/pull/183

The transient-saving Siren action in the `coa-eval-override` right-hand component is in the component itself, so it isn't mutexed in consistent-eval. Thus, performing the `publish` action before the transient-saving action to finish causes the component to not save correctly.

Changes:
* Pass in the `performSirenAction` promise to the change event of the achievement selector so that consistent-eval can await it prior to performing the `publish` action

https://rally1.rallydev.com/#/detail/defect/458210498988?fdp=true
