### PR TITLE
Fix new url component refresh

### DIFF
--- a/d2l-outcomes-coa-eval-override.js
+++ b/d2l-outcomes-coa-eval-override.js
@@ -26,7 +26,7 @@ export class D2lOutcomesCOAEvalOverride extends EntityMixinLit(LocalizeMixin(Lit
 
 	static get properties() {
 		return {
-			_initialStateLoaded: { attribute: false },
+			_loadedHref: { attribute: false },
 
 			_isOverrideActive: { attribute: false },
 
@@ -261,7 +261,7 @@ export class D2lOutcomesCOAEvalOverride extends EntityMixinLit(LocalizeMixin(Lit
 
 		this._setEntityType(DemonstrationEntity);
 
-		this._initialStateLoaded = false;
+		this._loadedHref = null;
 		this._isOverrideActive = false;
 		this._isOverrideAllowed = false;
 		this._newAssessmentsAdded = false;
@@ -296,14 +296,13 @@ export class D2lOutcomesCOAEvalOverride extends EntityMixinLit(LocalizeMixin(Lit
 			return;
 		}
 
-		if (!this._initialStateLoaded) {
-			this._loadInitialState(entity);
+		if (this.href !== this._loadedHref) {
+			this._loadEntityData(entity);
 		}
-
 		this._publishAction = entity.getPublishAction();
 	}
 
-	_loadInitialState(entity) {
+	_loadEntityData(entity) {
 		let calcMethod, calcMethodKey;
 		let helpMenuEntities = [];
 		entity.onCalcMethodChanged(method => {
@@ -352,7 +351,7 @@ export class D2lOutcomesCOAEvalOverride extends EntityMixinLit(LocalizeMixin(Lit
 			this._newAssessmentsAdded = newAssessments;
 			this._helpPopupItems = helpPopupItems;
 
-			this._initialStateLoaded = true;
+			this._loadedHref = this.href;
 		});
 	}
 

--- a/d2l-outcomes-level-of-achievements.js
+++ b/d2l-outcomes-level-of-achievements.js
@@ -160,6 +160,9 @@ export class D2lOutcomesLevelOfAchievements extends EntityMixinLit(LocalizeMixin
 				};
 				this._suggestedLevel = newSuggestedLevel;
 			}
+			else {
+				this._suggestedLevel = null;
+			}
 			this._hasAction = this._demonstrationLevels.some(level => !!level.action);
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-outcomes-level-of-achievements-ui",
   "name": "d2l-outcomes-level-of-achievements",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "directories": {
     "test": "test"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-outcomes-level-of-achievements-ui",
   "name": "d2l-outcomes-level-of-achievements",
-  "version": "3.0.16",
+  "version": "3.0.17",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Resolves two integration issues with the COA manual eval page:
- When iterating to the next/previous student, the manual override + recalculation buttons were not updated. Fixed by reloading the entity data anytime the href changes.
- Similarly, the LOA selector's suggested level would not be updated if the new student had no auto suggestion. Turned out to be a simple logic issue.