### PR TITLE
Performance improvement

### DIFF
--- a/d2l-outcomes-coa-eval-override.js
+++ b/d2l-outcomes-coa-eval-override.js
@@ -303,8 +303,16 @@ export class D2lOutcomesCOAEvalOverride extends EntityMixinLit(LocalizeMixin(Lit
 	}
 
 	_loadEntityData(entity) {
-		let calcMethod, calcMethodKey;
+		let calcMethod, calcMethodKey, newAssessments;
 		let helpMenuEntities = [];
+
+		entity.onOutdatedStatusChanged(status => {
+			if (!status) {
+				return;
+			}
+			newAssessments = status.getOutdatedStatus();
+		});
+
 		entity.onCalcMethodChanged(method => {
 			if (!method) {
 				return;
@@ -317,7 +325,6 @@ export class D2lOutcomesCOAEvalOverride extends EntityMixinLit(LocalizeMixin(Lit
 		entity.subEntitiesLoaded().then(() => {
 
 			const calcAchievementValue = entity.getCalculatedValue();
-			const newAssessments = entity.hasNewAssessments();
 			const levels = entity.getAllDemonstratableLevels();
 
 			const helpPopupItems = [];

--- a/demo/data/demonstrations/calculated/decaying-average-new-assessments.json
+++ b/demo/data/demonstrations/calculated/decaying-average-new-assessments.json
@@ -3,8 +3,7 @@
     "demonstration"
   ],
   "properties": {
-    "calculatedValue": "2.57",
-    "newAssessments": true
+    "calculatedValue": "2.57"
   },
   "entities": [
     {
@@ -178,6 +177,12 @@
         "calculation-method"
       ],
       "href": "data/calculation-methods/decaying-average.json"
+    },
+    {
+      "rel": [
+        "outdated-status"
+      ],
+      "href": "data/demonstrations/calculated/status/outdated.json"
     }
   ]
 }

--- a/demo/data/demonstrations/calculated/decaying-average.json
+++ b/demo/data/demonstrations/calculated/decaying-average.json
@@ -3,8 +3,7 @@
     "demonstration"
   ],
   "properties": {
-    "calculatedValue": "2.91",
-    "newAssessments": false
+    "calculatedValue": "2.91"
   },
   "entities": [
     {
@@ -178,6 +177,12 @@
         "calculation-method"
       ],
       "href": "data/calculation-methods/decaying-average.json"
+    },
+    {
+      "rel": [
+        "outdated-status"
+      ],
+      "href": "data/demonstrations/calculated/status/notOutdated.json"
     }
   ]
 }

--- a/demo/data/demonstrations/calculated/highest.json
+++ b/demo/data/demonstrations/calculated/highest.json
@@ -2,9 +2,7 @@
   "class": [
     "demonstration"
   ],
-  "properties": {
-    "newAssessments": false
-  },
+  "properties": {},
   "entities": [
     {
       "class": [
@@ -177,6 +175,12 @@
         "calculation-method"
       ],
       "href": "data/calculation-methods/highest.json"
+    },
+    {
+      "rel": [
+        "outdated-status"
+      ],
+      "href": "data/demonstrations/calculated/status/notOutdated.json"
     }
   ]
 }

--- a/demo/data/demonstrations/calculated/most-common-no-actions.json
+++ b/demo/data/demonstrations/calculated/most-common-no-actions.json
@@ -2,9 +2,7 @@
   "class": [
     "demonstration"
   ],
-  "properties": {
-    "newAssessments": false
-  },
+  "properties": {},
   "entities": [
     {
       "class": [
@@ -97,6 +95,12 @@
         "calculation-method"
       ],
       "href": "data/calculation-methods/most-common.json"
+    },
+    {
+      "rel": [
+        "outdated-status"
+      ],
+      "href": "data/demonstrations/calculated/status/notOutdated.json"
     }
   ]
 }

--- a/demo/data/demonstrations/calculated/most-common.json
+++ b/demo/data/demonstrations/calculated/most-common.json
@@ -2,9 +2,7 @@
   "class": [
     "demonstration"
   ],
-  "properties": {
-    "newAssessments": false
-  },
+  "properties": {},
   "entities": [
     {
       "class": [
@@ -177,6 +175,12 @@
         "calculation-method"
       ],
       "href": "data/calculation-methods/most-common.json"
+    },
+    {
+      "rel": [
+        "outdated-status"
+      ],
+      "href": "data/demonstrations/calculated/status/notOutdated.json"
     }
   ]
 }

--- a/demo/data/demonstrations/calculated/most-recent.json
+++ b/demo/data/demonstrations/calculated/most-recent.json
@@ -2,9 +2,7 @@
   "class": [
     "demonstration"
   ],
-  "properties": {
-    "newAssessments": false
-  },
+  "properties": {},
   "entities": [
     {
       "class": [
@@ -177,6 +175,12 @@
         "calculation-method"
       ],
       "href": "data/calculation-methods/most-recent.json"
+    },
+    {
+      "rel": [
+        "outdated-status"
+      ],
+      "href": "data/demonstrations/calculated/status/notOutdated.json"
     }
   ]
 }

--- a/demo/data/demonstrations/calculated/status/notOutdated.json
+++ b/demo/data/demonstrations/calculated/status/notOutdated.json
@@ -1,0 +1,22 @@
+{
+    "class": [
+        "demonstration-outdated-status"
+    ],
+    "properties": {
+        "IsOutdated": false
+    },
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "data/demonstrations/calculated/status/notOutdated.json"
+        },
+        {
+            "rel": [
+                "demonstration"
+            ],
+            "href": "about:blank"
+        }
+    ]
+}

--- a/demo/data/demonstrations/calculated/status/outdated.json
+++ b/demo/data/demonstrations/calculated/status/outdated.json
@@ -1,0 +1,22 @@
+{
+    "class": [
+        "demonstration-outdated-status"
+    ],
+    "properties": {
+        "IsOutdated": true
+    },
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "data/demonstrations/calculated/status/outdated.json"
+        },
+        {
+            "rel": [
+                "demonstration"
+            ],
+            "href": "about:blank"
+        }
+    ]
+}

--- a/entities/DemonstrationEntity.js
+++ b/entities/DemonstrationEntity.js
@@ -1,6 +1,7 @@
 import { Entity } from 'siren-sdk/src/es6/Entity';
-import { DemonstratableLevelEntity } from './DemonstratableLevelEntity';
 import { CalculationMethodEntity } from './CalculationMethodEntity';
+import { DemonstratableLevelEntity } from './DemonstratableLevelEntity';
+import { DemonstrationOutdatedStatusEntity } from './DemonstrationOutdatedStatusEntity';
 
 export class DemonstrationEntity extends Entity {
 	static get class() { return 'demonstration'; }
@@ -18,12 +19,15 @@ export class DemonstrationEntity extends Entity {
 		};
 	}
 
+	static get links() {
+		return {
+			calculationMethod: 'calculation-method',
+			outdatedStatus: 'outdated-status'
+		};
+	}
+
 	getCalculatedValue() {
 		return this._entity && this._entity.properties && this._entity.properties.calculatedValue;
-	}
-	//This might be changed later to compare assessment date with the most recent assessment (waiting on backend work)
-	hasNewAssessments() {
-		return this._entity && this._entity.properties && this._entity.properties.newAssessments;
 	}
 
 	getDemonstratedLevel() {
@@ -56,11 +60,24 @@ export class DemonstrationEntity extends Entity {
 		href && this._subEntity(CalculationMethodEntity, href, onChange);
 	}
 
+	onOutdatedStatusChanged(onChange) {
+		const href = this._outdatedStatusHref();
+		href && this._subEntity(DemonstrationOutdatedStatusEntity, href, onChange);
+	}
+
 	_calcMethodHref() {
-		if (!this._entity || !this._entity.hasLinkByRel('calculation-method')) {
+		if (!this._entity || !this._entity.hasLinkByRel(DemonstrationEntity.links.calculationMethod)) {
 			return;
 		}
 
-		return this._entity.getLinkByRel('calculation-method').href;
+		return this._entity.getLinkByRel(DemonstrationEntity.links.calculationMethod).href;
+	}
+
+	_outdatedStatusHref() {
+		if (!this._entity || !this._entity.hasLinkByRel(DemonstrationEntity.links.outdatedStatus)) {
+			return;
+		}
+
+		return this._entity.getLinkByRel(DemonstrationEntity.links.outdatedStatus).href;
 	}
 }

--- a/entities/DemonstrationOutdatedStatusEntity.js
+++ b/entities/DemonstrationOutdatedStatusEntity.js
@@ -1,0 +1,9 @@
+import { Entity } from 'siren-sdk/src/es6/Entity';
+
+export class DemonstrationOutdatedStatusEntity extends Entity {
+	static get class() { return 'demonstration-outdated-status'; }
+
+	getOutdatedStatus() {
+		return this._entity && this._entity.properties && this._entity.properties.IsOutdated;
+	}
+}


### PR DESCRIPTION
Get demonstration outdated status from link rather than prop.
Determining outdated status is expensive and should not be included on
each demonstration.

Depends on https://github.com/Brightspace/lms/pull/5871