### PR TITLE
Bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-level-of-achievements",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-outcomes-level-of-achievements-ui",
   "name": "d2l-outcomes-level-of-achievements",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Want to release translation updates to 20.21.4. Not needed for cert as there are no net new terms just clarification updates to existing terms.