### PR TITLE
Fix dependabot related PR's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,14 @@ jobs:
         run: npm ci
       - name: Test
         run: |
-          npm i karma-sauce-launcher@2 --no-save
-          npx karma start karma.sauce.conf.js
+          if ${{env.SAUCE_ACCESS_KEY != ''}}; then
+            echo "Running full test suite"
+            npm i karma-sauce-launcher@2 --no-save
+            npm run test:headless -- karma.sauce.conf.js
+          else
+            echo "Running minimal test suite"
+            npm run test:headless
+          fi
         env:
           SAUCE_USERNAME: Desire2Learn
           SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY_DESIRE2LEARN}}


### PR DESCRIPTION
Dependabot PR's down't have access to secrets. Run minimal local test if context isn't avaiable for sauce labs.